### PR TITLE
Enhancement docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,40 +26,15 @@ docker run --name some-crowi -p 8080:3000 -d \
 
 ### [Docker Compose](https://docs.docker.com/compose/)を使う
 
-MongoDBのコンテナを`db`として、Redisのコンテナを`redis`としてリンクできるようにしてあるので、例えば以下のように`docker-compose.yml`を書き、`docker-compose up`を実行すれば`http://localhost:8080`にアクセスして使えるようになります。
+MongoDBのコンテナを`db`として、Redisのコンテナを`redis`としてリンクできるようにしてあるので、例えば`docker-compose.yml`を用いて、`docker-compose up`を実行すれば`http://localhost:8080`にアクセスして使えるようになります。
 
-```yaml
-version: '2'
-
-services:
-	crowi:
-		image: bakudankun/crowi:1.4.0
-		links:
-			- mongo:db
-			- redis:redis
-		ports:
-			- 8080:3000
-
-	mongo:
-		image: mongo
-    volumes:
-      - ./data:/data/db
-
-	redis:
-		image: redis:alpine
+```
+$ wget https://raw.githubusercontent.com/Bakudankun/docker-crowi/master/docker-compose.yml
+$ docker-compose up -d
 ```
 
 イメージをアップデートする場合は、アップデートするイメージを`docker pull`した後に`docker-compose up`します。
 
-
-#### Quick Start
-
-面倒な人は以下のようなコマンドを打つ事で実行する事が可能です。
-
-```
-$ wget https://raw.githubusercontent.com/Bakudankun/docker-crowi/master/docker-compose.yml
-$ docker-compose up
-```
 
 ## 環境変数
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ services:
 
 	mongo:
 		image: mongo
+    volumes:
+      - ./data:/data/db
 
 	redis:
 		image: redis:alpine
@@ -49,6 +51,15 @@ services:
 
 イメージをアップデートする場合は、アップデートするイメージを`docker pull`した後に`docker-compose up`します。
 
+
+#### Quick Start
+
+面倒な人は以下のようなコマンドを打つ事で実行する事が可能です。
+
+```
+$ wget https://raw.githubusercontent.com/Bakudankun/docker-crowi/master/docker-compose.yml
+$ docker-compose up
+```
 
 ## 環境変数
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '2'
+
+services:
+  crowi:
+    image: bakudankun/crowi:1.4.0
+    links:
+      - mongo:db
+      - redis:redis
+    ports:
+      - 8080:3000
+
+  mongo:
+    image: mongo
+
+  redis:
+    image: redis:alpine

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,8 @@ services:
 
   mongo:
     image: mongo
+    volumes:
+      - ./data:/data/db
 
   redis:
     image: redis:alpine


### PR DESCRIPTION
- 今までREADMEに書かれていた `docker-compose.yml` ファイルを個別にgit管理下に入れました
  - それに伴い、wgetで取得するようにREADMEに記載しました
- docker-compose を用いた際に、MongoDBのデータボリュームをマウントし、wikiデータを永続化するようにしました
